### PR TITLE
feat: Add monorepo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ By default it uses the default `tsc` command with the `--noEmit` flag to avoid g
 }
 ```
 
+## FAQs
+
+### I'm using `nvim-notify` and being spammed by progress notifcations, what's going on?
+
+It's likely that the overwritten default `vim.notify` function isn't returning `nvim-notify`'s notification record, which is used to replace the existing notification. Make sure that you're nvim-notify configuration looks something like this:
+
+```lua
+require('notify')
+
+vim.notify = function(message, level, opts)
+  return notify(message, level, opts) -- <-- Important to return the value from `nvim-notify`
+end
+
+```
+
+### Why doesn't `tsc.nvim` typecheck my entire monorepo?
+
+In a monorepo setup, tsc.nvim only typechecks the current project by default because it uses the tsconfig.json of the current directory. If you need to typecheck across all projects in the monorepo, you must change the flags configuration option in the setup function from --noEmit to --build --composite. The --build flag instructs TypeScript to typecheck all referenced projects and the --composite flag enables project references and incremental builds for better management of dependencies and build performance. Your adjusted setup function should look like this:
+
+```lua
+require('tsc').setup({
+  flags = "--build --composite",
+})
+```
+
 ## Contributing
 
 Feel free to open issues or submit pull requests if you encounter any bugs or have suggestions for improvements. Your contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ By default it uses the default `tsc` command with the `--noEmit` flag to avoid g
 ```lua
 {
   auto_open_qflist = true,
+  enable_progress_notifications = true,
   flags = "--noEmit",
+  hide_progress_notifications_from_history = true,
   spinner = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
 }
 ```

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -194,11 +194,11 @@ end
 function M.setup(opts)
   config = vim.tbl_deep_extend("force", config, DEFAULT_CONFIG, opts or {})
 
-  vim.api.nvim_create_user_command(
-    "TSC",
-    M.run,
-    { desc = "Run `tsc` asynchronously and load the results into a qflist", force = true }
-  )
+  vim.api.nvim_create_user_command("TSC", function()
+    vim.cmd("silent cd %:h")
+    M.run()
+    vim.cmd("silent cd-")
+  end, { desc = "Run `tsc` asynchronously and load the results into a qflist", force = true })
 end
 
 return M

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -91,7 +91,7 @@ M.run = function()
   local notify_called = false
   local spinner_idx = 0
 
-  if vim.fn.executable(cmd) == 0 then
+  if utils.is_executable(cmd) then
     vim.notify(
       format_notification_msg(
         "tsc was not available or found in your node_modules or $PATH. Please run install and try again."

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -91,7 +91,7 @@ M.run = function()
   local notify_called = false
   local spinner_idx = 0
 
-  if utils.is_executable(cmd) then
+  if not utils.is_executable(cmd) then
     vim.notify(
       format_notification_msg(
         "tsc was not available or found in your node_modules or $PATH. Please run install and try again."

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -9,7 +9,7 @@ M.get_root_dir = function()
 end
 
 M.get_tsc_cmd = function()
-  local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc", M.get_root_dir())
+  local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc;", M.get_root_dir())
 
   if node_modules_tsc_binary ~= "" then
     return node_modules_tsc_binary

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -4,10 +4,6 @@ M.is_executable = function(cmd)
   return cmd and vim.fn.executable(cmd) == 1 or false
 end
 
-M.get_root_dir = function()
-  return vim.loop.cwd()
-end
-
 M.get_tsc_cmd = function()
   local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc", ".;")
 

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -9,7 +9,7 @@ M.get_root_dir = function()
 end
 
 M.get_tsc_cmd = function()
-  local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc;", M.get_root_dir())
+  local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc", ".;")
 
   if node_modules_tsc_binary ~= "" then
     return node_modules_tsc_binary


### PR DESCRIPTION
# feat: Add monorepo support
The current iteration of `tsc.nvim` does not cater well to monorepo setups. This limitation arises primarily from two factors. Firstly, when `:TSC` is run, the root of your project serves as the current directory. If your root does not contain a `tsconfig.json` file, `tsc` (the TypeScript compiler) fails to find it while performing a backward search through the filesystem. Secondly, to typecheck monorepos housing multiple projects, the `--build` and `--composite` (composite is optional) flags are essential.
## Changes
- Sets the neovim's `cd` to the current buffers path, runs `tsc.nvim` (which enables `tsc` to successfully perform a backwards search), and then resets neovims `cd` to the previous path/dir.
- Because of the former point, we no longer search for the `tsc` binary starting in the project root and instead need to perform a backwards search from the current buffer directory.
