### PR TITLE
Pretty ts errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tsc.nvim
+
 <img width="569" alt="image" src="https://user-images.githubusercontent.com/2755722/233876554-efb9cfe6-c038-46c8-a7cb-b7a4aa9eac5b.png">
 
 This Neovim plugin provides an asynchronous interface to run project-wide TypeScript type-checking using the TypeScript compiler (`tsc`). It displays the type-checking results in a quickfix list and provides visual notifications about the progress and completion of type-checking.
@@ -83,7 +84,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   },
   hide_progress_notifications_from_history = true,
   spinner = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
-  pretty_errors = false,
+  pretty_errors = true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   },
   hide_progress_notifications_from_history = true,
   spinner = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
+  pretty_errors = false,
 }
 ```
 

--- a/lua/tsc/better-messages-test.lua
+++ b/lua/tsc/better-messages-test.lua
@@ -1,0 +1,48 @@
+local bm = require("tsc.better-messages")
+
+describe("Does the basics", function()
+  it("Replaces the original text with the correct md file text", function()
+    local original_message = "TS7061: A mapped type may not declare properties or methods"
+    local expected_message = "TS7061: You're trying to create a mapped type with both static and dynamic properties."
+    assert.equals(expected_message, bm.best_message(original_message))
+  end)
+end)
+
+describe("Handles slots", function()
+  it("Handles a message with one slot", function()
+    local original_message = "TS2604: JSX element type 'BadComponent' does not have any construct or call signatures."
+    local expected_message = "TS2604: 'BadComponent' cannot be used as a JSX component because it isn't a function."
+    assert.equals(expected_message, bm.best_message(original_message))
+  end)
+  it("Handles a message with multiple slots", function()
+    local original_message = "TS2551: Property 'foo' does not exist on type 'bar'. Did you mean 'baz'?"
+    local expected_message =
+      "TS2551: You're trying to access 'foo' on an object that doesn't contain it. Did you mean 'baz'?"
+    assert.equals(expected_message, bm.best_message(original_message))
+  end)
+end)
+
+describe("Handles links", function()
+  it("Removes a 'read more' link", function()
+    local original_message = "TS7006: Parameter 'foo' implicitly has an 'bar' type."
+    -- check 7006.md to see original pretty message with link
+    local expected_message =
+      "TS7006: I don't know what type 'foo' is supposed to be, so I've defaulted it to 'bar'. Your `tsconfig.json` file says I should throw an error here."
+    assert.equals(expected_message, bm.best_message(original_message))
+  end)
+  it("Removes a 'this article' link and sentence", function()
+    local original_message =
+      "TS7053: Element implicitly has an 'any' type because expression of type 'foo' can't be used to index type 'bar'."
+    -- check 7053.md to see original pretty message with link
+    local expected_message = "TS7053: You can't use 'foo' to index into 'bar'."
+    assert.equals(expected_message, bm.best_message(original_message))
+  end)
+  it("Handles removes other links href, keeps link text", function()
+    local original_message =
+      "TS1268: An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type."
+    -- check 1268.md to see original pretty message with link
+    local expected_message =
+      "TS1268: Objects in TypeScript (and JavaScript!) can only have strings, numbers or symbols as keys. Template literal types are a way of constructing strings."
+    assert.equals(expected_message, bm.best_message(original_message))
+  end)
+end)

--- a/lua/tsc/better-messages.lua
+++ b/lua/tsc/better-messages.lua
@@ -1,0 +1,129 @@
+local M = {}
+
+--- Gets a pointer to the improved text file, if it exists. Not every error
+--- requires additional description.
+--- @param error_num string: the original compiler message to parse
+--- @return file* | nil
+local function get_improved_text_file(error_num)
+  local filename = error_num .. ".md"
+  local plugin_path = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":p:h")
+  return io.open(plugin_path .. "/better-messages/" .. filename, "r")
+end
+
+--- Removes link text from the string, keeping those with relevant text.
+--- @param line string
+--- @return string
+local function parse_out_links(line)
+  local link_re = "%[(.+)%]%((.+)%)"
+  local link_start, link_end, match = line:find(link_re)
+  if link_start == nil or link_end == nil then
+    return line
+  end
+
+  if match == "Learn more" then
+    return line:sub(0, link_start - 2)
+  end
+
+  if match == "This article" then
+    local sentence_end = line:find("%.", link_end)
+    if sentence_end == nil then
+      return line:sub(0, link_start - 2) .. line:sub(link_end)
+    end
+    return line:sub(0, link_start - 2) .. line:sub(sentence_end)
+  end
+
+  return line:sub(0, link_start - 1) .. match .. line:sub(link_end + 1)
+end
+
+--- @class MDFile
+--- @field frontmatter table<string, string>
+--- @field body string
+
+--- Returns a markdown file object with frontmatter and content
+--- @param md_file file*
+--- @return MDFile
+local function parse_md_simple(md_file)
+  local md = { frontmatter = {}, body = "" }
+  local in_frontmatter = false
+  for l in md_file:lines("l") do
+    if not in_frontmatter and l == "---" then
+      in_frontmatter = true
+      goto continue
+    elseif in_frontmatter and l == "---" then
+      in_frontmatter = false
+      goto continue
+    elseif in_frontmatter then
+      local sep_idx = l:find(":")
+      local key = l:sub(0, sep_idx - 1)
+      local val = l:sub(sep_idx + 3, l:len() - 1)
+      md.frontmatter[key] = val
+    else
+      md.body = md.body .. parse_out_links(l)
+    end
+    ::continue::
+  end
+
+  return md
+end
+
+--- Get any slots out of the improved text for matching.
+--- @param md MDFile
+local function get_improved_text_slots(md)
+  local slots = {}
+  --- @type integer | nil
+  local i = 0
+  while true do
+    i = md.body:find("%{%d%}", i + 1)
+    if i == nil then
+      break
+    end
+    local val = md.body:sub(i, i + 2)
+    table.insert(slots, val)
+  end
+  return slots
+end
+
+--- Match a slot with the text from the original message
+--- @param slots table<integer, string>
+--- @param original_message string
+--- @param md_original_message string
+--- @return table<string, string>
+local function match_slots(slots, original_message, md_original_message)
+  local matched_slots = {}
+  for i = 1, #slots do
+    local idx = md_original_message:find(slots[i])
+    local match = original_message:match("%w+", idx)
+    matched_slots[slots[i]] = match
+  end
+  return matched_slots
+end
+
+--- Finds and parses a preferred message md file, or returns the existing if no
+--- preferred message is available.
+--- @param message string: the original compiler message to parse
+--- @return string
+M.best_message = function(message)
+  local error_num, original_message = message:match("^.*TS(%d+):%s(.*)")
+  local improved_text_file = get_improved_text_file(error_num)
+  if improved_text_file == nil then
+    return message
+  end
+
+  local md = parse_md_simple(improved_text_file)
+
+  local slots = get_improved_text_slots(md)
+  if #slots == 0 then
+    return md.body
+  end
+
+  local matched_slots = match_slots(slots, original_message, md.frontmatter["original"])
+
+  local output_message = md.body
+  for k, v in pairs(matched_slots) do
+    output_message = output_message:gsub(k, v)
+  end
+
+  return "TS" .. error_num .. ": " .. output_message
+end
+
+return M

--- a/lua/tsc/better-messages.lua
+++ b/lua/tsc/better-messages.lua
@@ -29,7 +29,7 @@ local function parse_out_links(line)
     if sentence_end == nil then
       return line:sub(0, link_start - 2) .. line:sub(link_end)
     end
-    return line:sub(0, link_start - 2) .. line:sub(sentence_end)
+    return line:sub(0, link_start - 2) .. line:sub(sentence_end + 1)
   end
 
   return line:sub(0, link_start - 1) .. match .. line:sub(link_end + 1)
@@ -113,7 +113,7 @@ M.best_message = function(message)
 
   local slots = get_improved_text_slots(md)
   if #slots == 0 then
-    return md.body
+    return "TS" .. error_num .. ": " .. md.body
   end
 
   local matched_slots = match_slots(slots, original_message, md.frontmatter["original"])

--- a/lua/tsc/better-messages/1002.md
+++ b/lua/tsc/better-messages/1002.md
@@ -1,0 +1,5 @@
+---
+original: 'Unterminated string literal.'
+---
+
+You've started a string (via a single or double quote) but haven't ended it.

--- a/lua/tsc/better-messages/1003.md
+++ b/lua/tsc/better-messages/1003.md
@@ -1,0 +1,5 @@
+---
+original: 'Identifier expected.'
+---
+
+I was expecting a name but none was provided.

--- a/lua/tsc/better-messages/1006.md
+++ b/lua/tsc/better-messages/1006.md
@@ -1,0 +1,5 @@
+---
+original: 'A file cannot have a reference to itself.'
+---
+
+You've got a triple-slash reference inside a file that's referencing itself.

--- a/lua/tsc/better-messages/1009.md
+++ b/lua/tsc/better-messages/1009.md
@@ -1,0 +1,5 @@
+---
+original: 'Trailing comma not allowed.'
+---
+
+You've added a trailing comma when you're not supposed to add it.

--- a/lua/tsc/better-messages/1014.md
+++ b/lua/tsc/better-messages/1014.md
@@ -1,0 +1,5 @@
+---
+original: 'A rest parameter must be last in a parameter list.'
+---
+
+A parameter in a function that starts with `...` must be the last one in the list.

--- a/lua/tsc/better-messages/1015.md
+++ b/lua/tsc/better-messages/1015.md
@@ -1,0 +1,5 @@
+---
+original: 'Parameter cannot have question mark and initializer.'
+---
+
+You can use a question mark or an default value, but not both at once.

--- a/lua/tsc/better-messages/1091.md
+++ b/lua/tsc/better-messages/1091.md
@@ -1,0 +1,5 @@
+---
+original: "Only a single variable declaration is allowed in a 'for...in' statement."
+---
+
+You can only create a single variable in a 'for...in' statement

--- a/lua/tsc/better-messages/1109.md
+++ b/lua/tsc/better-messages/1109.md
@@ -1,0 +1,5 @@
+---
+original: 'Expression expected.'
+---
+
+I am expecting a code that resolves to a value.

--- a/lua/tsc/better-messages/1117.md
+++ b/lua/tsc/better-messages/1117.md
@@ -1,0 +1,5 @@
+---
+original: 'An object literal cannot have multiple properties with the same name.'
+---
+
+You can't add the same property multiple times to an object.

--- a/lua/tsc/better-messages/1155.md
+++ b/lua/tsc/better-messages/1155.md
@@ -1,0 +1,5 @@
+---
+original: "'const' declarations must be initialized."
+---
+
+A `const` must be given a value when it's declared.

--- a/lua/tsc/better-messages/1163.md
+++ b/lua/tsc/better-messages/1163.md
@@ -1,0 +1,5 @@
+---
+original: "A 'yield' expression is only allowed in a generator body."
+---
+
+The `yield` keyword can only be used inside a generator function

--- a/lua/tsc/better-messages/1208.md
+++ b/lua/tsc/better-messages/1208.md
@@ -1,0 +1,5 @@
+---
+original: "'{0}' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module."
+---
+
+You have set the 'isolatedModules' flag. Therefore all implementation files must be modules (which means it has some form of import/export). Add an import, export, or an empty 'export {}' statement to make it a module.

--- a/lua/tsc/better-messages/1240.md
+++ b/lua/tsc/better-messages/1240.md
@@ -1,0 +1,5 @@
+---
+original: 'Unable to resolve signature of property decorator when called as an expression.'
+---
+
+You can't use a decorator on an expression, like an arrow function.

--- a/lua/tsc/better-messages/1254.md
+++ b/lua/tsc/better-messages/1254.md
@@ -1,0 +1,5 @@
+---
+original: "A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference."
+---
+
+You can't use runtime code in a declaration file.

--- a/lua/tsc/better-messages/1268.md
+++ b/lua/tsc/better-messages/1268.md
@@ -1,0 +1,5 @@
+---
+original: "An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type."
+---
+
+Objects in TypeScript (and JavaScript!) can only have strings, numbers or symbols as keys. [Template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) are a way of constructing strings.

--- a/lua/tsc/better-messages/1313.md
+++ b/lua/tsc/better-messages/1313.md
@@ -1,0 +1,5 @@
+---
+original: "The body of an 'if' statement cannot be the empty statement."
+---
+
+An if statement shouldn't be empty

--- a/lua/tsc/better-messages/1434.md
+++ b/lua/tsc/better-messages/1434.md
@@ -1,0 +1,5 @@
+---
+original: 'Unexpected keyword or identifier.'
+---
+
+There's a syntax error in your code, so I can't tell exactly what's wrong.

--- a/lua/tsc/better-messages/17004.md
+++ b/lua/tsc/better-messages/17004.md
@@ -1,0 +1,5 @@
+---
+original: "Cannot use JSX unless the '--jsx' flag is provided."
+---
+
+You can't use JSX yet because you haven't added `jsx` to your `tsconfig.json`. [Learn more](https://www.totaltypescript.com/cannot-use-jsx-unless-the-jsx-flag-is-provided).

--- a/lua/tsc/better-messages/18004.md
+++ b/lua/tsc/better-messages/18004.md
@@ -1,0 +1,5 @@
+---
+original: "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer."
+---
+
+You're trying to pass '{0}' as a key AND value to this object using a shorthand. You'll need to declare '{0}' as a variable first.

--- a/lua/tsc/better-messages/2304.md
+++ b/lua/tsc/better-messages/2304.md
@@ -1,0 +1,5 @@
+---
+original: "Cannot find name '{0}'."
+---
+
+I can't find the variable you're trying to access.

--- a/lua/tsc/better-messages/2305.md
+++ b/lua/tsc/better-messages/2305.md
@@ -1,0 +1,5 @@
+---
+original: "Module '{0}' has no exported member '{1}'."
+---
+
+'{1}' is not one of the things exported from '{0}'.

--- a/lua/tsc/better-messages/2307.md
+++ b/lua/tsc/better-messages/2307.md
@@ -1,0 +1,5 @@
+---
+original: "Cannot find module '{0}' or its corresponding type declarations."
+---
+
+This could be one of two things - either '{0}' doesn't exist on your file system, or I can't find any type declarations for it.

--- a/lua/tsc/better-messages/2312.md
+++ b/lua/tsc/better-messages/2312.md
@@ -1,0 +1,5 @@
+---
+original: 'An interface can only extend an object type or intersection of object types with statically known members.'
+---
+
+You might be trying to use an interface to extend a union type. This isn't possible.

--- a/lua/tsc/better-messages/2314.md
+++ b/lua/tsc/better-messages/2314.md
@@ -1,0 +1,5 @@
+---
+original: "Generic type '{0}' requires {1} type argument(s)."
+---
+
+It looks like '{0}' requires '{1}' type arguments, which means you need to pass them in via a generic.

--- a/lua/tsc/better-messages/2322.md
+++ b/lua/tsc/better-messages/2322.md
@@ -1,0 +1,5 @@
+---
+original: "Type '{0}' is not assignable to type '{1}'."
+---
+
+I was expecting a type matching '{1}', but instead you passed '{0}'.

--- a/lua/tsc/better-messages/2324.md
+++ b/lua/tsc/better-messages/2324.md
@@ -1,0 +1,5 @@
+---
+original: "Property '{0}' is missing in type '{1}'."
+---
+
+You haven't passed all the required properties to '{1}' - you've missed out '{0}'

--- a/lua/tsc/better-messages/2326.md
+++ b/lua/tsc/better-messages/2326.md
@@ -1,0 +1,5 @@
+---
+original: "Types of property '{0}' are incompatible."
+---
+
+Two similar types have a property '{0}' which is different, making them incompatible.

--- a/lua/tsc/better-messages/2327.md
+++ b/lua/tsc/better-messages/2327.md
@@ -1,0 +1,5 @@
+---
+original: "Property '{0}' is optional in type '{1}' but required in type '{2}'."
+---
+
+Property '{0}' in type '{2}' must exist.

--- a/lua/tsc/better-messages/2339.md
+++ b/lua/tsc/better-messages/2339.md
@@ -1,0 +1,5 @@
+---
+original: "Property '{0}' does not exist on type '{1}'."
+---
+
+You're trying to access '{0}' on an object that doesn't contain it. [Learn more](https://totaltypescript.com/concepts/property-does-not-exist-on-type).

--- a/lua/tsc/better-messages/2344.md
+++ b/lua/tsc/better-messages/2344.md
@@ -1,0 +1,5 @@
+---
+original: "Type '{0}' does not satisfy the constraint '{1}'."
+---
+
+You're trying to pass in '{0}' into a slot where I can see only '{1}' can be passed.

--- a/lua/tsc/better-messages/2345.md
+++ b/lua/tsc/better-messages/2345.md
@@ -1,0 +1,5 @@
+---
+original: "Argument of type '{0}' is not assignable to parameter of type '{1}'."
+---
+
+I was expecting '{1}', but you passed '{0}'.

--- a/lua/tsc/better-messages/2349.md
+++ b/lua/tsc/better-messages/2349.md
@@ -1,0 +1,5 @@
+---
+original: 'This expression is not callable.'
+---
+
+I can't call this expression because I can't call it like a function.

--- a/lua/tsc/better-messages/2352.md
+++ b/lua/tsc/better-messages/2352.md
@@ -1,0 +1,5 @@
+---
+original: "Conversion of type '{0}' to type '{1}' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first."
+---
+
+You can't use 'as' to convert '{0}' into a '{1}' - they don't share enough in common.

--- a/lua/tsc/better-messages/2353.md
+++ b/lua/tsc/better-messages/2353.md
@@ -1,0 +1,5 @@
+---
+original: "Object literal may only specify known properties, and '{0}' does not exist in type '{1}'."
+---
+
+You can't pass property '{0}' to type '{1}'.

--- a/lua/tsc/better-messages/2355.md
+++ b/lua/tsc/better-messages/2355.md
@@ -1,0 +1,5 @@
+---
+original: "A function whose declared type is neither 'void' nor 'any' must return a value."
+---
+
+You set the function return type but it is not returning anything.

--- a/lua/tsc/better-messages/2365.md
+++ b/lua/tsc/better-messages/2365.md
@@ -1,0 +1,5 @@
+---
+original: "Operator '{0}' cannot be applied to types '{1}' and '{2}'."
+---
+
+You can't use '{0}' on the types '{1}' and '{2}'.

--- a/lua/tsc/better-messages/2393.md
+++ b/lua/tsc/better-messages/2393.md
@@ -1,0 +1,5 @@
+---
+original: 'Duplicate function implementation.'
+---
+
+You've already declared a function with the same name.

--- a/lua/tsc/better-messages/2414.md
+++ b/lua/tsc/better-messages/2414.md
@@ -1,0 +1,5 @@
+---
+original: "Class name cannot be '{0}'"
+---
+
+You can't give a class the name of '{0}' because it's protected by TypeScript.

--- a/lua/tsc/better-messages/2451.md
+++ b/lua/tsc/better-messages/2451.md
@@ -1,0 +1,5 @@
+---
+original: "Cannot redeclare block-scoped variable '{0}'."
+---
+
+'{0}' has already been declared - you can't declare it again. [Learn more](https://www.totaltypescript.com/cannot-redeclare-block-scoped-variable).

--- a/lua/tsc/better-messages/2488.md
+++ b/lua/tsc/better-messages/2488.md
@@ -1,0 +1,5 @@
+---
+original: "Type '{0}' must have a '[Symbol.iterator]()' method that returns an iterator."
+---
+
+Type '{0}' isn't iterable. To make it iterable, add a [`Symbol.iterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator) key.

--- a/lua/tsc/better-messages/2551.md
+++ b/lua/tsc/better-messages/2551.md
@@ -1,0 +1,5 @@
+---
+original: "Property '{0}' does not exist on type '{1}'. Did you mean '{2}'?"
+---
+
+You're trying to access '{0}' on an object that doesn't contain it. Did you mean '{2}'?

--- a/lua/tsc/better-messages/2552.md
+++ b/lua/tsc/better-messages/2552.md
@@ -1,0 +1,5 @@
+---
+original: "Cannot find name '{0}'. Did you mean '{1}'?"
+---
+
+You are trying to reference a function or variable which I can't find in the current scope.

--- a/lua/tsc/better-messages/2554.md
+++ b/lua/tsc/better-messages/2554.md
@@ -1,0 +1,5 @@
+---
+original: 'Expected {0} arguments, but got {1}.'
+---
+
+The function you're trying to call needs {0} arguments, but you're passing {1}.

--- a/lua/tsc/better-messages/2556.md
+++ b/lua/tsc/better-messages/2556.md
@@ -1,0 +1,5 @@
+---
+original: 'A spread argument must either have a tuple type or be passed to a rest parameter.'
+---
+
+You're spreading arguments into a function. To do that, either the argument needs to be a tuple OR the function needs to accept a dynamic number of arguments.

--- a/lua/tsc/better-messages/2571.md
+++ b/lua/tsc/better-messages/2571.md
@@ -1,0 +1,5 @@
+---
+original: "Object is of type 'unknown'."
+---
+
+I don't know what type this object is, so I've defaulted it to 'unknown'. [Learn more](https://www.totaltypescript.com/concepts/object-is-of-type-unknown).

--- a/lua/tsc/better-messages/2590.md
+++ b/lua/tsc/better-messages/2590.md
@@ -1,0 +1,5 @@
+---
+original: 'undefined'
+---
+
+You've created a union type that's too complex for me to handle! 🤯 I can only represent 100,000 combinations in the same union, and you've gone over that limit.

--- a/lua/tsc/better-messages/2604.md
+++ b/lua/tsc/better-messages/2604.md
@@ -1,0 +1,5 @@
+---
+original: "JSX element type '{0}' does not have any construct or call signatures."
+---
+
+'{0}' cannot be used as a JSX component because it isn't a function.

--- a/lua/tsc/better-messages/2614.md
+++ b/lua/tsc/better-messages/2614.md
@@ -1,0 +1,5 @@
+---
+original: "Module '{0}' has no exported member '{1}'. Did you mean to use 'import {1} from {0}' instead?"
+---
+
+'{1}' is not one of the things exported from '{0}'. Did you mean to import '{1}' from '{0}' instead?

--- a/lua/tsc/better-messages/2686.md
+++ b/lua/tsc/better-messages/2686.md
@@ -1,0 +1,5 @@
+---
+original: "'{0}' refers to a UMD global, but the current file is a module. Consider adding an import instead."
+---
+
+You might not have configured `jsx` in your `tsconfig.json` correctly. [Learn more](https://www.totaltypescript.com/react-refers-to-a-umd-global).

--- a/lua/tsc/better-messages/2722.md
+++ b/lua/tsc/better-messages/2722.md
@@ -1,0 +1,5 @@
+---
+original: "Cannot invoke an object which is possibly 'undefined'."
+---
+
+This function might be undefined. You'll need to check it's defined before calling it.

--- a/lua/tsc/better-messages/2739.md
+++ b/lua/tsc/better-messages/2739.md
@@ -1,0 +1,5 @@
+---
+original: "Type '{0}' is missing the following properties from type '{1}': {2}"
+---
+
+'{0}' is missing some required properties from type '{1}': {2}.

--- a/lua/tsc/better-messages/2741.md
+++ b/lua/tsc/better-messages/2741.md
@@ -1,0 +1,5 @@
+---
+original: "Property '{0}' is missing in type '{1}' but required in type '{2}'."
+---
+
+You haven't passed all the required properties to '{2}' - '{1}' is missing the '{0}' property.

--- a/lua/tsc/better-messages/2749.md
+++ b/lua/tsc/better-messages/2749.md
@@ -1,0 +1,5 @@
+---
+original: "'{0}' refers to a value, but is being used as a type here. Did you mean 'typeof {0}'?"
+---
+
+You're trying to use a JavaScript variable where you should be passing a type.

--- a/lua/tsc/better-messages/2761.md
+++ b/lua/tsc/better-messages/2761.md
@@ -1,0 +1,5 @@
+---
+original: "Type '{0}' has no construct signatures."
+---
+
+Type '{0}' is not a class.

--- a/lua/tsc/better-messages/2775.md
+++ b/lua/tsc/better-messages/2775.md
@@ -1,0 +1,5 @@
+---
+original: 'Assertions require every name in the call target to be declared with an explicit type annotation.'
+---
+
+You might be using an `asserts` keyword on an arrow function. If you are, change the function to use the `function` keyword.

--- a/lua/tsc/better-messages/2783.md
+++ b/lua/tsc/better-messages/2783.md
@@ -1,0 +1,5 @@
+---
+original: "'{0}' is specified more than once, so this usage will be overwritten."
+---
+
+'{0}' will be overwritten by the spread.

--- a/lua/tsc/better-messages/5075.md
+++ b/lua/tsc/better-messages/5075.md
@@ -1,0 +1,5 @@
+---
+original: "'{0}' is assignable to the constraint of type '{1}', but '{1}' could be instantiated with a different subtype of constraint '{2}'."
+---
+
+You're passing a type '{0}' into a slot which is too narrow. It could be as wide as anything assignable to '{2}'.

--- a/lua/tsc/better-messages/6133.md
+++ b/lua/tsc/better-messages/6133.md
@@ -1,0 +1,5 @@
+---
+original: "'{0}' is declared but its value is never read."
+---
+
+I noticed that '{0}' has been declared, but it's never used in the code.

--- a/lua/tsc/better-messages/6142.md
+++ b/lua/tsc/better-messages/6142.md
@@ -1,0 +1,5 @@
+---
+original: "Module '{0}' was resolved to '{1}', but '--jsx' is not set."
+---
+
+You can't import `.jsx` or `.tsx` files until you set `jsx` in your `tsconfig.json`.

--- a/lua/tsc/better-messages/6244.md
+++ b/lua/tsc/better-messages/6244.md
@@ -1,0 +1,5 @@
+---
+original: "Cannot access ambient const enums when 'isolatedModules' is enabled."
+---
+
+You can't use const enums when `isolatedModules` is enabled.

--- a/lua/tsc/better-messages/7006.md
+++ b/lua/tsc/better-messages/7006.md
@@ -1,0 +1,5 @@
+---
+original: "Parameter '{0}' implicitly has an '{1}' type."
+---
+
+I don't know what type '{0}' is supposed to be, so I've defaulted it to '{1}'. Your `tsconfig.json` file says I should throw an error here. [Learn more](https://www.totaltypescript.com/tutorials/beginners-typescript/beginner-s-typescript-section/implicit-any-type-error).

--- a/lua/tsc/better-messages/7026.md
+++ b/lua/tsc/better-messages/7026.md
@@ -1,0 +1,5 @@
+---
+original: "JSX element implicitly has type 'any' because no interface 'JSX.{0}' exists."
+---
+
+`JSX.IntrinsicElements` has not been declared in the global scope. [Learn more](https://www.totaltypescript.com/what-is-jsx-intrinsicelements).

--- a/lua/tsc/better-messages/7053.md
+++ b/lua/tsc/better-messages/7053.md
@@ -1,0 +1,5 @@
+---
+original: "Element implicitly has an 'any' type because expression of type '{0}' can't be used to index type '{1}'."
+---
+
+You can't use '{0}' to index into '{1}'. [This article](https://www.totaltypescript.com/concepts/type-string-cannot-be-used-to-index-type) might help.

--- a/lua/tsc/better-messages/7057.md
+++ b/lua/tsc/better-messages/7057.md
@@ -1,0 +1,5 @@
+---
+original: "'yield' expression implicitly results in an 'any' type because its containing generator lacks a return-type annotation."
+---
+
+I don't know enough about your generator function's return type to safely infer here.

--- a/lua/tsc/better-messages/7061.md
+++ b/lua/tsc/better-messages/7061.md
@@ -1,0 +1,5 @@
+---
+original: 'A mapped type may not declare properties or methods.'
+---
+
+You're trying to create a mapped type with both static and dynamic properties.

--- a/lua/tsc/better-messages/8016.md
+++ b/lua/tsc/better-messages/8016.md
@@ -1,0 +1,5 @@
+---
+original: 'Type assertion expressions can only be used in TypeScript files.'
+---
+
+You can't use type assertions because this isn't a TypeScript file.

--- a/lua/tsc/better-messages/95050.md
+++ b/lua/tsc/better-messages/95050.md
@@ -1,0 +1,5 @@
+---
+original: 'Remove unreachable code'
+---
+
+I've spotted a bit of code that will never be run.

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -22,7 +22,7 @@ local DEFAULT_CONFIG = {
   },
   hide_progress_notifications_from_history = true,
   spinner = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
-  pretty_errors = false,
+  pretty_errors = true,
 }
 
 local DEFAULT_NOTIFY_OPTIONS = {

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -111,7 +111,7 @@ M.run = function()
   end
 
   local function on_stdout(_, output)
-    local result = utils.parse_tsc_output(output, config.pretty_errors)
+    local result = utils.parse_tsc_output(output, config)
 
     errors = result.errors
     files_with_errors = result.files

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -22,6 +22,7 @@ local DEFAULT_CONFIG = {
   },
   hide_progress_notifications_from_history = true,
   spinner = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
+  pretty_errors = false,
 }
 
 local DEFAULT_NOTIFY_OPTIONS = {
@@ -110,7 +111,7 @@ M.run = function()
   end
 
   local function on_stdout(_, output)
-    local result = utils.parse_tsc_output(output)
+    local result = utils.parse_tsc_output(output, config.pretty_errors)
 
     errors = result.errors
     files_with_errors = result.files

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -1,3 +1,5 @@
+local better_messages = require("tsc.better-messages")
+
 local M = {}
 
 M.is_executable = function(cmd)
@@ -75,7 +77,7 @@ M.parse_tsc_output = function(output)
         filename = filename,
         lnum = tonumber(lineno),
         col = tonumber(colno),
-        text = message,
+        text = better_messages.best_message(message),
         type = "E",
       })
 

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -62,7 +62,7 @@ M.parse_flags = function(flags)
   return parsed_flags
 end
 
-M.parse_tsc_output = function(output, should_show_pretty_errors)
+M.parse_tsc_output = function(output, config)
   local errors = {}
   local files = {}
 
@@ -74,7 +74,7 @@ M.parse_tsc_output = function(output, should_show_pretty_errors)
     local filename, lineno, colno, message = line:match("^(.+)%((%d+),(%d+)%)%s*:%s*(.+)$")
     if filename ~= nil then
       local text = message
-      if should_show_pretty_errors then
+      if config.pretty_errors then
         text = better_messages.best_message(message)
       end
       table.insert(errors, {

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -62,7 +62,7 @@ M.parse_flags = function(flags)
   return parsed_flags
 end
 
-M.parse_tsc_output = function(output)
+M.parse_tsc_output = function(output, should_show_pretty_errors)
   local errors = {}
   local files = {}
 
@@ -73,11 +73,15 @@ M.parse_tsc_output = function(output)
   for _, line in ipairs(output) do
     local filename, lineno, colno, message = line:match("^(.+)%((%d+),(%d+)%)%s*:%s*(.+)$")
     if filename ~= nil then
+      local text = message
+      if should_show_pretty_errors then
+        text = better_messages.best_message(message)
+      end
       table.insert(errors, {
         filename = filename,
         lnum = tonumber(lineno),
         col = tonumber(colno),
-        text = better_messages.best_message(message),
+        text = text,
         type = "E",
       })
 


### PR DESCRIPTION
This resolves #7.

The provided test file can be run with `:PlenaryBustedFile %`.

The MD files are pulled from [Matt Pocock's repo](https://github.com/mattpocock/ts-error-translator/tree/main/packages/engine/errors), on which this concept was based.

Thanks!