### PR TITLE
Avoid combining nil values while translating compiler messages

### DIFF
--- a/lua/tsc/better-messages.lua
+++ b/lua/tsc/better-messages.lua
@@ -97,7 +97,7 @@ M.translate = function(message)
 
   local params = get_params(parsed["original"])
 
-  if #params == 0 then
+  if #params == 0 and parsed.body then
     return "TS" .. error_num .. ": " .. parsed.body
   end
 


### PR DESCRIPTION
This patch will handle the following error message by checking the `body` value before using it.

> tsc.nvim/lua/tsc/better-messages.lua:101: attempt to concatenate field 'body' (a nil value)