### PR TITLE
add trouble integration option, expose open and close usercmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   auto_close_qflist = false,
   auto_focus_qflist = false,
   auto_start_watch_mode = false,
+  use_trouble_qflist = false,
   bin_path = utils.find_tsc_bin(),
   enable_progress_notifications = true,
   flags = {
@@ -97,6 +98,26 @@ With this configuration, you can use keys for flag names and their corresponding
 
 ```lua
 flags = "--noEmit",
+```
+
+## Manual Opening and Closing the Quickfix List
+
+There are two user commands you can use to open and close the quickfix list:
+
+`TSCOpen` - open the quickfix list
+`TSCClose` - close the quickfix list
+
+These commands will respect your configuration options:
+
+- `auto_open_qflist`
+- `auto_close_qflist`
+- `use_trouble_qflist`
+
+### Example key maps:
+
+```lua
+vim.keymap.set('n', '<leader>to', ':TSCOpen<CR>')
+vim.keymap.set('n', '<leader>tc', ':TSCClose<CR>')
 ```
 
 ## FAQs
@@ -127,6 +148,18 @@ require('tsc').setup({
 ```
 
 With this configuration, tsc.nvim will typecheck all projects in the monorepo, taking into account project references and incremental builds.
+
+### Can I use `Trouble` for the quickfix list?
+
+Yes, as long as you have the plugin installed you can set `use_trouble_qflist = true` in the configuration.
+
+```lua
+require('tsc').setup({
+    use_trouble_qflist = true,
+})
+```
+
+This will use Trouble for the quickfix list. This will work with all other options such as `auto_open_qflist`, `auto_close_qflist`, `auto_focus_qflist`.
 
 ## Contributing
 

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -14,6 +14,7 @@ local DEFAULT_CONFIG = {
   auto_close_qflist = false,
   auto_focus_qflist = false,
   auto_start_watch_mode = false,
+  use_trouble_qflist = false,
   bin_path = utils.find_tsc_bin(),
   enable_progress_notifications = true,
   flags = {
@@ -131,6 +132,7 @@ M.run = function()
       auto_open = config.auto_open_qflist,
       auto_close = config.auto_close_qflist,
       auto_focus = config.auto_focus_qflist,
+      use_trouble = config.use_trouble_qflist,
     })
 
     if not config.enable_progress_notifications then
@@ -203,6 +205,14 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("TSC", function()
     M.run()
   end, { desc = "Run `tsc` asynchronously and load the results into a qflist", force = true })
+
+  vim.api.nvim_create_user_command("TSCOpen", function()
+    utils.open_qflist(config.use_trouble_qflist, config.auto_focus_qflist)
+  end, { desc = "Open the results in a qflist", force = true })
+
+  vim.api.nvim_create_user_command("TSCClose", function()
+    utils.close_qflist(config.use_trouble_qflist)
+  end, { desc = "Close the results qflist", force = true })
 
   if config.flags.watch then
     vim.api.nvim_create_autocmd("BufWritePre", {


### PR DESCRIPTION
This approach adds a more prescriptive but easier use of Trouble. By having trouble installed and enabling the option, the module check does remove the dependance on trouble.


there is another approach where instead of opting into use_trouble_qflist we could instead add two options to pass a function for on_qflist_opened and on_qflist_close. This would allow for a more flexible integration for users but would put the work on the user to provide the correct functionality.

