### PR TITLE
add ability to have multiple tsc jobs running / watching for mono rep…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   auto_focus_qflist = false,
   auto_start_watch_mode = false,
   use_trouble_qflist = false,
+  use_as_monorepo = false,
   bin_path = utils.find_tsc_bin(),
   enable_progress_notifications = true,
   flags = {
@@ -139,13 +140,11 @@ end
 
 ### Why doesn't tsc.nvim typecheck my entire monorepo?
 
-In a monorepo setup, tsc.nvim only typechecks the project associated with the nearest `tsconfig.json` by default. If you need to typecheck across all projects in the monorepo, you must change the flags configuration option in the setup function to include `--build`. The `--build` flag instructs TypeScript to typecheck all referenced projects, taking into account project references and incremental builds for better management of dependencies and build performance. Your adjusted setup function should look like this:
+By default, the plugin will check only the nearest `tsconfig` file. If you would like it to use all `tsconfig` files in the current working directory, set `use_as_monorepo = true`. All other options will work as usual such as `auto_start_watch_mode`, `flags.watch`, etc.
 
 ```lua
 require('tsc').setup({
-  flags = {
-    build = true,
-  },
+    use_as_monorepo = true,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   auto_focus_qflist = false,
   auto_start_watch_mode = false,
   use_trouble_qflist = false,
-  use_as_monorepo = false,
+  run_as_monorepo = false,
   bin_path = utils.find_tsc_bin(),
   enable_progress_notifications = true,
   flags = {
@@ -140,11 +140,11 @@ end
 
 ### Why doesn't tsc.nvim typecheck my entire monorepo?
 
-By default, tsc.nvim will check only the nearest `tsconfig` file. If you would like it to use all `tsconfig` files in the current working directory, set `use_as_monorepo = true`. All other options will work as usual such as `auto_start_watch_mode`, `flags.watch`, etc.
+By default, tsc.nvim will check only the nearest `tsconfig` file. If you would like it to use all `tsconfig` files in the current working directory, set `run_as_monorepo = true`. All other options will work as usual such as `auto_start_watch_mode`, `flags.watch`, etc.
 
 ```lua
 require('tsc').setup({
-    use_as_monorepo = true,
+    run_as_monorepo = true,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ To run TypeScript type-checking, execute the `:TSC` command in Neovim. The plugi
 
 If `watch` mode is enabled, tsc.nvim will automatically run in the background every time you save in a typescript or tsx file and report the results back to you. In addition, if `auto_start_watch_mode` is enabled, the `:TSC` command will be executed on your behalf when you enter a typescript or tsx files.
 
+To stop any running `:TSC` command, use the `:TSCStop` command in Neovim.
+
 ## Configuration
 
 By default, the plugin uses the default `tsc` command with the `--noEmit` flag to avoid generating output files during type-checking. It also emulates the default tsc behavior of performing a backward search from the current directory for a `tsconfig` file. The flags option can accept both a string and a table. Here's the default configuration:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ end
 
 ### Why doesn't tsc.nvim typecheck my entire monorepo?
 
-By default, the plugin will check only the nearest `tsconfig` file. If you would like it to use all `tsconfig` files in the current working directory, set `use_as_monorepo = true`. All other options will work as usual such as `auto_start_watch_mode`, `flags.watch`, etc.
+By default, tsc.nvim will check only the nearest `tsconfig` file. If you would like it to use all `tsconfig` files in the current working directory, set `use_as_monorepo = true`. All other options will work as usual such as `auto_start_watch_mode`, `flags.watch`, etc.
 
 ```lua
 require('tsc').setup({

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -79,7 +79,6 @@ M.run = function()
   config.flags.project = utils.find_nearest_tsconfig()
 
   if M.is_running(config.flags.project) then
-    vim.notify(format_notification_msg("Type-checking already in progress"), vim.log.levels.WARN, get_notify_options())
     return
   end
 
@@ -209,6 +208,14 @@ function M.setup(opts)
   config = vim.tbl_deep_extend("force", config, DEFAULT_CONFIG, opts or {})
 
   vim.api.nvim_create_user_command("TSC", function()
+    if M.is_running(config.flags.project) then
+      vim.notify(
+        format_notification_msg("Type-checking already in progress"),
+        vim.log.levels.WARN,
+        get_notify_options()
+      )
+      return
+    end
     M.run()
   end, { desc = "Run `tsc` asynchronously and load the results into a qflist", force = true })
 

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -30,9 +30,9 @@ M.find_tsconfigs = function(run_mono_repo)
 
   local found_configs = nil
   if M.is_executable("rg") then
-    found_configs = vim.fn.system("rg -g '!node_modules' --files | rg tsconfig")
+    found_configs = vim.fn.system("rg -g '!node_modules' --files | rg 'tsconfig.*.json'")
   else
-    found_configs = vim.fn.system('find . -name "tsconfig*" -type f')
+    found_configs = vim.fn.system('find . -not -path "*/node_modules/*" -name "tsconfig.*.json" -type f')
   end
 
   if found_configs == nil then

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -19,14 +19,42 @@ M.find_tsc_bin = function()
   return "tsc"
 end
 
+--- @param run_mono_repo boolean
+--- @return table<string>
+M.find_tsconfigs = function(run_mono_repo)
+  if not run_mono_repo then
+    return M.find_nearest_tsconfig()
+  end
+
+  local tsconfigs = {}
+
+  local found_configs = nil
+  if M.is_executable("rg") then
+    found_configs = vim.fn.system("rg -g '!node_modules' --files | rg tsconfig")
+  else
+    found_configs = vim.fn.system('find . -name "tsconfig*" -type f')
+  end
+
+  if found_configs == nil then
+    return {}
+  end
+
+  for s in found_configs:gmatch("[^\r\n]+") do
+    table.insert(tsconfigs, s)
+  end
+
+  assert(tsconfigs)
+  return tsconfigs
+end
+
 M.find_nearest_tsconfig = function()
   local tsconfig = vim.fn.findfile("tsconfig.json", ".;")
 
   if tsconfig ~= "" then
-    return tsconfig
+    return { tsconfig }
   end
 
-  return nil
+  return {}
 end
 
 M.parse_flags = function(flags)
@@ -107,12 +135,12 @@ M.set_qflist = function(errors, opts)
     M.open_qflist(final_opts.use_trouble, final_opts.auto_focus)
   end
 
-  if #errors == 0 then
-    -- trouble needs to be refreshed when list is empty.
-    if final_opts.use_trouble and trouble ~= nil then
-      trouble.refresh()
-    end
+  -- trouble needs to be refreshed when list is empty.
+  if final_opts.use_trouble and trouble ~= nil then
+    trouble.refresh()
+  end
 
+  if #errors == 0 then
     if final_opts.auto_close then
       M.close_qflist(final_opts.use_trouble)
     end


### PR DESCRIPTION
This allows for multiple watch processes to be running simultaniously.
It will only run one per tsconfig project. This will allow for mono repo projects to use watch across all sub repos. This does not change any existing functionality.

running TSC in an open buffer will find the nearest tsconfig file upwards. and if there is no process currently running against that project it will start one and log the job id. This can then be checked against on subsequent attempts to run tsc if it is in watch modAe.

I have also added a :TSCStop usrcmd to allow stopping all watching processes.