### PR TITLE
fix(flags): fix support for config.flags as a string

### DIFF
--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -263,12 +263,15 @@ M.run = function()
       end
     end
 
+    local flags = ""
+    if type(config.flags) == "string" then
+      flags = config.flags
+    else
+      flags = utils.parse_flags(vim.tbl_extend("force", config.flags, { project = project }))
+    end
     vim.schedule(function()
       running_processes[project] = {
-        pid = vim.fn.jobstart(
-          tsc .. " " .. utils.parse_flags(vim.tbl_extend("force", config.flags, { project = project })),
-          project_opts
-        ),
+        pid = vim.fn.jobstart(tsc .. " " .. flags, project_opts),
         errors = {},
       }
     end)


### PR DESCRIPTION
Part of commit [02856f0](https://github.com/dmmulroy/tsc.nvim/commit/02856f0c67741a7c060df8f24a7f2806e1935f46) broke support for handling `config.flags` as a string.

[lua/tsc/init.lua#L269](https://github.com/dmmulroy/tsc.nvim/blob/main/lua/tsc/init.lua#L269) assumes `config.flags` is a table, passing it into `tbl_extend`. If `config.flags` is supplied as a string, this function call will error