### PR TITLE
feat: added use_diagnostics option to populate diagnostics list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   auto_focus_qflist = false,
   auto_start_watch_mode = false,
   use_trouble_qflist = false,
+  use_diagnostics = false,
   run_as_monorepo = false,
   bin_path = utils.find_tsc_bin(),
   enable_progress_notifications = true,
@@ -161,6 +162,14 @@ require('tsc').setup({
 ```
 
 This will use Trouble for the quickfix list. This will work with all other options such as `auto_open_qflist`, `auto_close_qflist`, `auto_focus_qflist`.
+
+### Can it show the error list directly in my file explorer (like nvim-tree)
+
+Yes. As file explorers uses LSP diagnostics, you can use the `use_diagnostics` option in order to populate the diagnostics list as well as the quickfix list
+
+```
+use_diagnostics = true
+```
 
 ## Contributing
 

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -181,6 +181,7 @@ M.run = function()
 
     if config.use_diagnostics then
       local namespace_id = vim.api.nvim_create_namespace("tsc_diagnostics")
+      vim.diagnostic.reset(namespace_id)
 
       for _, error in ipairs(errors) do
         local bufnr = vim.fn.bufnr(error.filename)
@@ -188,7 +189,15 @@ M.run = function()
           vim.notify("Buffer not found for " .. error.filename, vim.log.levels.ERROR, get_notify_options())
           return
         end
-        vim.diagnostic.set(namespace_id, bufnr, { error }, {})
+        local diagnostic = {
+          bufnr = bufnr,
+          lnum = error.lnum - 1,
+          col = error.col - 1,
+          severity = vim.diagnostic.severity.ERROR,
+          message = error.text,
+          source = "tsc",
+        }
+        vim.diagnostic.set(namespace_id, bufnr, { diagnostic }, {})
       end
     end
 


### PR DESCRIPTION
This option make tsc.nvim able to populate LSP diagnostics list with the error found. This could be useful for showing diags in file explorers like nvim-tree. This is the result when the option is enabled : 


https://github.com/dmmulroy/tsc.nvim/assets/75337003/93a534cd-3e85-47c8-a5aa-c1bb5c7ecf0f


This is my very first contribution to a neovim plugin, feel free to blame me if I broke something, either the plugin integrity or philosophy.