### PR TITLE
Support yarn2 projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ To set up the plugin, add the following line to your `init.vim` or `init.lua` fi
 require('tsc').setup()
 ```
 
+For [yarn2](https://yarnpkg.com/) projects, you will need to generate the base SDK for handling typescript correctly:
+
+```bash
+yarn dlx @yarnpkg/sdks base
+```
+
+See [Editor SDKs](https://yarnpkg.com/getting-started/editor-sdks) for more information about configuring your IDE.
+
 ## Usage
 
 To run TypeScript type-checking, execute the `:TSC` command in Neovim. The plugin will display a progress notification while the type-checking is in progress. When the type-checking is complete, it will show a notification with the results and open a quickfix list if there are any errors.

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -12,6 +12,10 @@ end
 M.find_tsc_bin = function()
   local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc", ".;")
 
+  if node_modules_tsc_binary == "" then
+    node_modules_tsc_binary = vim.fn.findfile(".yarn/sdks/typescript/bin/tsc", ".;")
+  end
+
   if node_modules_tsc_binary ~= "" then
     return node_modules_tsc_binary
   end


### PR DESCRIPTION
In a standard yarn2 project, the absence of a `node_modules` directory means that the `node_modules/.bin/tsc` file won't be located by the `find_tsc_bin` function. Instead, yarn2 offers a utility to generate SDKs, which enables editors like Vim or VSCode to function seamlessly in a TypeScript environment. The TypeScript binary within the base SDK is located at `.yarn/sdks/typescript/bin/tsc`.