### PR TITLE
Lazyvim: Support snacks notifier and prevent notification toast duplication

### DIFF
--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -49,6 +49,7 @@ local DEFAULT_CONFIG = {
 local DEFAULT_NOTIFY_OPTIONS = {
   title = "TSC",
   hide_from_history = false,
+  id = "tsc.nvim",
 }
 
 local config = {} ---@type Opts


### PR DESCRIPTION
Notifications don't have an id, which makes every loading step send a new notification instead of updating the existing one

See issue: https://github.com/dmmulroy/tsc.nvim/issues/59

I'm adding an id value to the default config to apply it everywhere. I tried adding it only to the `Type-checking your project` notification on line 144 but it was still duplicating the notification (only twice instead of hundreds of times though)

I think having a single id for all notifications would be okay as they most likely won't conflict with each other ?