### PR TITLE
feat: add snacks.nvim notifer support

### DIFF
--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -138,7 +138,7 @@ M.run = function()
       ),
       nil,
       get_notify_options(
-        (notify_record and { replace = notify_record.id }),
+        (notify_record and { replace = notify_record.id, id = notify_record.id }),
         (config.hide_progress_notifications_from_history and notify_called and { hide_from_history = true })
       )
     )


### PR DESCRIPTION
### Description

Adding snacks.nvim's notifier support, in `nvim-notify` opt `replace` used as `id` but in `snacks.nvim` it uses `id` field, see: https://github.com/folke/snacks.nvim/blob/main/lua/snacks/notifier.lua#L21