### PR TITLE
feat: add max_configs_to_run param

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   use_trouble_qflist = false,
   use_diagnostics = false,
   run_as_monorepo = false,
+  max_configs_to_run = 20,
   bin_path = utils.find_tsc_bin(),
   enable_progress_notifications = true,
   enable_error_notifications = true,

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ By default, the plugin uses the default `tsc` command with the `--noEmit` flag t
   use_trouble_qflist = false,
   use_diagnostics = false,
   run_as_monorepo = false,
-  max_configs_to_run = 20,
+  max_tsconfig_files = 20,
   bin_path = utils.find_tsc_bin(),
   enable_progress_notifications = true,
   enable_error_notifications = true,

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -17,6 +17,7 @@ end
 --- @field use_trouble_qflist? boolean - (false) When true the quick fix list will be opened in Trouble if it is installed
 --- @field use_diagnostics? boolean - (false) When true the errors will be set as diagnostics
 --- @field run_as_monorepo? boolean - (false) When true the `tsc` process will be started mode for each tsconfig in the current working directory
+--- @field max_configs_to_run? number - (20) Will not run `tsc` if number of found tsconfig files in monorepo is greater.
 --- @field bin_path? string - Path to the tsc binary if it is not in the projects node_modules or globally
 --- @field enable_progress_notifications? boolean - (true) When false progress notifications will not be shown
 --- @field enable_error_notifications? boolean - (true) When false error notifications will not be shown
@@ -36,6 +37,7 @@ local DEFAULT_CONFIG = {
   enable_progress_notifications = true,
   enable_error_notifications = true,
   run_as_monorepo = false,
+  max_configs_to_run = 20,
   flags = {
     noEmit = true,
     project = nil,
@@ -112,7 +114,7 @@ M.run = function()
     end
   end
 
-  if #configs_to_run > 20 then
+  if #configs_to_run > config.max_configs_to_run then
     vim.notify_once("Too many tsconfigs found: " .. #configs_to_run, vim.log.levels.ERROR, get_notify_options())
     return
   end

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -17,7 +17,7 @@ end
 --- @field use_trouble_qflist? boolean - (false) When true the quick fix list will be opened in Trouble if it is installed
 --- @field use_diagnostics? boolean - (false) When true the errors will be set as diagnostics
 --- @field run_as_monorepo? boolean - (false) When true the `tsc` process will be started mode for each tsconfig in the current working directory
---- @field max_configs_to_run? number - (20) Will not run `tsc` if number of found tsconfig files is greater.
+--- @field max_tsconfig_files? number - (20) Will not run `tsc` if number of found tsconfig files is greater.
 --- @field bin_path? string - Path to the tsc binary if it is not in the projects node_modules or globally
 --- @field enable_progress_notifications? boolean - (true) When false progress notifications will not be shown
 --- @field enable_error_notifications? boolean - (true) When false error notifications will not be shown
@@ -37,7 +37,7 @@ local DEFAULT_CONFIG = {
   enable_progress_notifications = true,
   enable_error_notifications = true,
   run_as_monorepo = false,
-  max_configs_to_run = 20,
+  max_tsconfig_files = 20,
   flags = {
     noEmit = true,
     project = nil,
@@ -114,7 +114,7 @@ M.run = function()
     end
   end
 
-  if #configs_to_run > config.max_configs_to_run then
+  if #configs_to_run > config.max_tsconfig_files then
     vim.notify_once("Too many tsconfigs found: " .. #configs_to_run, vim.log.levels.ERROR, get_notify_options())
     return
   end

--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -17,7 +17,7 @@ end
 --- @field use_trouble_qflist? boolean - (false) When true the quick fix list will be opened in Trouble if it is installed
 --- @field use_diagnostics? boolean - (false) When true the errors will be set as diagnostics
 --- @field run_as_monorepo? boolean - (false) When true the `tsc` process will be started mode for each tsconfig in the current working directory
---- @field max_configs_to_run? number - (20) Will not run `tsc` if number of found tsconfig files in monorepo is greater.
+--- @field max_configs_to_run? number - (20) Will not run `tsc` if number of found tsconfig files is greater.
 --- @field bin_path? string - Path to the tsc binary if it is not in the projects node_modules or globally
 --- @field enable_progress_notifications? boolean - (true) When false progress notifications will not be shown
 --- @field enable_error_notifications? boolean - (true) When false error notifications will not be shown


### PR DESCRIPTION
Add a `max_configs_to_run` (somebody got a better name?) param that defaults to previously hardcoded `20` to allow plugin user to increase the number of allowed `tsconfig` files.

My monorepo has 26 `tsconfig` files and I was prohibited by the set max of `20` to run `:TSC`.

Or is there a specific to reason to not go over 20 files?

Thanks for the great work on this plugin.

