### PR TITLE
Fix for tsc bin can't be found

### DIFF
--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -10,7 +10,7 @@ M.is_executable = function(cmd)
 end
 
 M.find_tsc_bin = function()
-  local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc", ".;")
+  local node_modules_tsc_binary = vim.fn.findfile("node_modules/.bin/tsc", vim.fn.getcwd() .. ";")
 
   if node_modules_tsc_binary ~= "" then
     return node_modules_tsc_binary
@@ -48,7 +48,7 @@ M.find_tsconfigs = function(run_mono_repo)
 end
 
 M.find_nearest_tsconfig = function()
-  local tsconfig = vim.fn.findfile("tsconfig.json", ".;")
+  local tsconfig = vim.fn.findfile("tsconfig.json", vim.fn.getcwd() .. ";")
 
   if tsconfig ~= "" then
     return { tsconfig }


### PR DESCRIPTION
See issue: #28 

In some cases path to TSC binary can't be resolved and :TSC command returns an error.
This might happen because if you open `nvim .` some plugins like nvim-tree might change working directory.
I can't properly reproduce or understand what happens because right after start if you execute vim.fn.findfile("node_modules/.bin/tsc", ".;") it resolves tsc binary absolutely fine.

To fix it we can make sure that we get real project root by vim.fn.getcwd()

Without this fix if I open project with `nvim .` tsc binary can't be resolved