### PR TITLE
fix: find_nearest_config not working in monorepo

### DIFF
--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -48,7 +48,7 @@ M.find_tsconfigs = function(run_mono_repo)
 end
 
 M.find_nearest_tsconfig = function()
-  local tsconfig = vim.fn.findfile("tsconfig.json", vim.fn.getcwd() .. ";")
+  local tsconfig = vim.fn.findfile("tsconfig.json", ".;")
 
   if tsconfig ~= "" then
     return { tsconfig }


### PR DESCRIPTION
## Summary
The recent change in #64 has broke the plugin's ability to find `tsconfig.json` in a monorepo setup.
While the change that searches for `tsc` binary might be reasonable, I don't believe that the change to the `find_nearest_tsconfig` was correct.

The plugin just stopped working and on `:TSC` command run, all I get is `Type-checking already in progress` error.

According to the vim help:
> findfile({name} [, {path} [, {count}]])                             *findfile()*
		Example: >vim
			echo findfile("tags.vim", ".;")
<		Searches from the directory of the current file upwards until
		it finds the file "tags.vim".

Since the `vim.fn.findfile` searches **up the tree**, if the search will start at `cwd` it will only work if the `tsconfig.json` exists in the `cwd`.

However, this won't work in a monorepo setup.

## Reproduction

Here's an example of a common monorepo:
```
.
├── apps
│   ├── app1
│   │   ├── index.ts
│   │   ├── tsconfig.json # extends ../../tsconfig.base.json
│   └── app2
│   │   ├── index.ts
│       ├── tsconfig.json # extends ../../tsconfig.base.json
├── tsconfig.base.json

```

Previously, if you were in the `/apps/app1/index.ts` the search started from it and was finding the `tsconfig.json` file next to it.
Now it starts at `cwd`, doesn't find `tsconfig.json` and shows an error.