### PR TITLE
Allow the user to default a bin_path or find one when ran

### DIFF
--- a/lua/tsc/init.lua
+++ b/lua/tsc/init.lua
@@ -32,7 +32,7 @@ local DEFAULT_CONFIG = {
   auto_start_watch_mode = false,
   use_trouble_qflist = false,
   use_diagnostics = false,
-  bin_path = utils.find_tsc_bin(),
+  bin_path = nil,
   enable_progress_notifications = true,
   enable_error_notifications = true,
   run_as_monorepo = false,
@@ -81,7 +81,7 @@ end
 
 M.run = function()
   -- Closed over state
-  local tsc = config.bin_path
+  local tsc = config.bin_path or utils.find_tsc_bin()
   local errors = {}
   local files_with_errors = {}
   local notify_record


### PR DESCRIPTION
The first time I used this plugin I ran into the fact that I start nvim in a parent directory of my repo.  So when I cd into the repo and run :TSC it does not work.  This will prevent that as it will instead look for the tsc file when I run :TSC.

This will also allow people to navigate to multiple typescript repos with different tsc bin_paths.  I'm not sure if that's really that helpful or not.

This should help issues like this:  https://github.com/dmmulroy/tsc.nvim/issues/28#issuecomment-2680086826 and possibly even this one: https://github.com/dmmulroy/tsc.nvim/issues/28#issuecomment-2058789954

Let me know if a different configuration is wanted or if this isn't wanted at all.

