### PR TITLE
Updates documentation with lazy config and vim notify information

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ Plug 'dmmulroy/tsc.nvim'
 
 Then run `:PlugInstall` to install the plugin.
 
-### Notify
-
-For an enhanced UI/UX experience, it is recommended to install the [nvim_notify](https://github.com/rcarriga/nvim-notify) plugin as well. This plugin is optional, and the plugin will work without it.
-
 ## Setup
+
+> **Notifications**
+>
+> For an enhanced UI/UX experience, it is recommended to install the [nvim_notify](https://github.com/rcarriga/nvim-notify) plugin as well. This plugin is optional, and the plugin will work without it.
+>
+> For this plugin to work with vim-notify, you will need to ensure that `vim.notify = require("notify")` has been added to your NeoVim configuration
 
 To set up the plugin, add the following line to your `init.vim` or `init.lua` file:
 


### PR DESCRIPTION
Adds the lazy.nvim example, and I missed the section on the notifications part of this plugin.

This change will:

 - Add `lazy.nvim` setup example
 - Move the content into the setup section
 - Use a callout to highlight the information
 - Add a line to highlight that `vim.notify` needs setting