### PR TITLE
feat: typescript-tools.vim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ https://user-images.githubusercontent.com/2755722/233818163-bd2c2dda-88fc-41ea-a
 
 https://user-images.githubusercontent.com/2755722/233843746-ee116863-bef5-4e26-ba0a-afb906a2f111.mov
 
+### typescript-tools.nvim integration
+
+You can translate the Typescript errors as they show up in your buffer by passing the following handler to [typescript-tools.nvim]:
+
+```lua
+return {
+    {
+        "dmmulroy/tsc.nvim",
+        opts = { }
+    },
+    {
+        "pmizio/typescript-tools.nvim",
+        dependencies = {"nvim-lua/plenary.nvim", "dmmulroy/tsc.nvim"},
+        opts = {
+            settings = {
+                handlers = {
+                    ["textDocument/publishDiagnostics"] = function (...)
+                        local tsc_utils = require('tsc.utils')
+                        return tsc_utils.text_document_published_diagnostics_handler(...)
+                    end
+                }
+            }
+        }
+}
+```
+
+<img alt="Screenshot 2026-01-15 at 10 05 02" src="https://github.com/user-attachments/assets/e26b66eb-e974-4dbd-b114-ae58ecad759f" />
+
 ## Installation
 
 To install the plugin, use your preferred Neovim plugin manager.
@@ -281,3 +309,5 @@ Feel free to open issues or submit pull requests if you encounter any bugs or ha
 ## License
 
 This plugin is released under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+[typescript-tools.nvim]: https://github.com/pmizio/typescript-tools.nvim

--- a/lua/tsc/better-messages.lua
+++ b/lua/tsc/better-messages.lua
@@ -106,5 +106,26 @@ M.translate = function(message)
   return "TS" .. error_num .. ": " .. better_error
 end
 
+--- @param diagnostic lsp.Diagnostic
+--- @return lsp.Diagnostic
+M.translate_lsp_diagnostic = function(diagnostic)
+  local improved_text_file = get_error_markdown_file(diagnostic.code)
+  if improved_text_file == nil then
+    return diagnostic
+  end
+
+  local parsed = parse_md(improved_text_file)
+
+  local params = get_params(parsed["original"])
+
+  if #params == 0 and parsed.body then
+    diagnostic.message = parsed.body
+    return diagnostic
+  end
+
+  diagnostic.message = better_error_message(diagnostic.message, parsed["original"], parsed["better"])
+  return diagnostic
+end
+
 -- Returning the module M.
 return M

--- a/lua/tsc/utils.lua
+++ b/lua/tsc/utils.lua
@@ -182,4 +182,25 @@ M.close_qflist = function(use_trouble)
   end
 end
 
+--- @param diagnostic lsp.Diagnostic
+local translate_diagnostic = function(diagnostic)
+  diagnostic.message = better_messages.translate(("TS" .. diagnostic.code .. ": " .. diagnostic.message))
+
+  return diagnostic
+end
+
+--- Translate diagnostics as they get published on each document.
+---
+--- This helper is meant to be consumed as a custom handler for the 'textDocument/publishDiagnostics' event.
+--- @param err lsp.ResponseError?
+--- @param res lsp.PublishDiagnosticsParams
+--- @param ctx lsp.HandlerContext
+M.text_document_published_diagnostics_handler = function(err, res, ctx, ...)
+  res.diagnostics = vim.tbl_map(better_messages.translate_lsp_diagnostic, res.diagnostics)
+
+  --- typescript-tools passes a fourth undocumented param, we're forwarding it to match the behavior
+  ---@diagnostic disable-next-line: redundant-parameter
+  return vim.lsp.diagnostic.on_publish_diagnostics(err, res, ctx, ...)
+end
+
 return M


### PR DESCRIPTION
We can reuse the translations displayed in the quickfix window in the actual diagnostics sent by the LSP server.

typescript-tools.nvim provides a way to override the `textDocument/publishDiagnostics` handler. We can intercept the diagnostics and with a small reformat, we can feed it into the `translate` helper.

Note that we're not including the `TS<code>:` prefix to let each user format the diagnostics however they want.

<img width="1106" height="139" alt="Screenshot 2026-01-15 at 10 05 02" src="https://github.com/user-attachments/assets/e26b66eb-e974-4dbd-b114-ae58ecad759f" />
